### PR TITLE
Add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-mod-submission.yml
+++ b/.github/ISSUE_TEMPLATE/1-mod-submission.yml
@@ -1,0 +1,30 @@
+name: "Mod submission"
+description: "Submitting a mod on to the mod browser"
+title: "[Mod Submission]: "
+body: 
+- type: markdown
+  attributes:
+    value: |
+      Thank you for submitting a mod on the mod browser! Please note that we have easier submission portal inside our discord server.
+      Please put your mod name in the title of the issue before continuing filling the form.
+
+- type: checkboxes
+  attributes:
+    label: "Is this an update to existing mod?"
+    options:
+      - label: "Yes, this is an update to existing mod."
+
+- type: textarea
+  attributes:
+    label: "Mod Description"
+    description: "How would you like to describe your mod on the mod browser? If there are previews please include them in this text"
+    placeholder: "This is a pretty cool mod! It does X!"
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "The Mod Itself"
+    description: "Either drag and drop the mod into this text area or paste link to hosted file here."
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/2-datapack-submission.yml
+++ b/.github/ISSUE_TEMPLATE/2-datapack-submission.yml
@@ -1,0 +1,22 @@
+name: "Datapack submission"
+description: "Submitting a Datapack on to the datapack browser"
+title: "[Datapack Submission]: "
+body: 
+- type: markdown
+  attributes:
+    value: |
+      Thank you for submitting a datapack on the datapack browser! Please note that we have easier submission portal inside our discord server.
+      Please put your datapack name in the title of the issue before continuing filling the form.
+
+- type: checkboxes
+  attributes:
+    label: "Is this an update to existing datapack?"
+    options:
+      - label: "Yes, this is an update to existing datapack."
+
+- type: textarea
+  attributes:
+    label: "The Datapack Itself"
+    description: "Paste link to hosted file here. You can put the datapack on any third-party file hosting service like Google Drive, DropBox, etc."
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/3-datapackscanner-issues.yml
+++ b/.github/ISSUE_TEMPLATE/3-datapackscanner-issues.yml
@@ -1,0 +1,24 @@
+name: "DatapackScanner Issues"
+description: "Submitting issue on DatapackScanner"
+title: "[DatapackScanner Issue]: "
+body: 
+- type: markdown
+  attributes:
+    value: |
+      Thank you for interested in DatapackScanner and want to make it better by submitting bug report/request for it.
+
+- type: dropdown
+  attributes:
+    label: "Is this bug report or feature request?"
+    options: 
+      - Bug Report
+      - Feature Request
+    default: 0
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Text Area"
+    description: "Put in relevent data in here you see fit. If you do not provide enough information, we'll request you to provide more information."
+    

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: BDCC Discord
+    url: https://discord.com/invite/7UGYBvQrc3
+    about: Discord server where you can ask general questions and easily submitting mods or datapacks. You must be over 18 or not on Apple devices to join.


### PR DESCRIPTION
This will force future issue submission to this repo to follow a format I made. There are 3 issue forms, 
1) Mod submission
2) Datapack submission
3) DatapackScanner bug report/feature request

I felt like this repo needed these templates for few reasons
- People who can't join our discord for the following reasons
  - They're banned from the discord for reasons other than underage
  - iPhone and iPads
- People who don't have an discord account